### PR TITLE
CI setup -- test make targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,46 +1,50 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+orbs:
+  go: circleci/go@2.2.4
+
 jobs:
   build:
-    circleci_ip_ranges: true
-    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
-    docker:
-      - image: cimg/base:stable
-    # Add steps to the job
-    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    executor:
+      name: go/default
+      tag: '1.23'
     steps:
       - checkout
-      - run:
-          name: "build stage"
-          command: "echo build stage"
+      - go/with-cache:
+          steps:
+            - go/mod-download
+            - run:
+                name: Generate Command Files
+                command: make generate-cmd
+            - run:
+                name: Format Check
+                command: make fmt
+            - run:
+                name: Build
+                command: make build
+            - run: 
+                name: Install
+                command: make install
+            
   test:
-    docker:
-      - image: cimg/base:stable
+    executor:
+      name: go/default
+      tag: '1.23'
     steps:
-      - run:
-          name: "test stage"
-          command: "echo test stage"
-  package:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - run:
-          name: "package stage"
-          command: "echo package stage"
-# Invoke jobs via workflows
-# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+      - checkout
+      - go/with-cache:
+          steps:
+            - go/mod-download
+            - go/test:
+                covermode: atomic
+                race: true
+                verbose: true
+
 workflows:
-  build-and-test:
+  version: 2
+  build-test:
     jobs:
       - build
       - test:
           requires:
             - build
-      - package:
-          requires:
-            - test

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ dep: # Download required dependencies
 # 	go build -o $(GOBIN)/okta-cli cmd/okta-cli/main.go
 
 build:
-	go build -o $(GOBIN)/okta-cli-client okta-cli-client
+	go build -o $(GOBIN)/okta-cli-client . 
 
 install:
 	go install .


### PR DESCRIPTION
With these changes, circleCI reproduces the errors that I encounter when running `make generate-cmd` and then `make install`  locally. Also fixed `make build` because the old syntax for it caused "package not in std" errors in CI, whereas this gets it through to the errors which also appear on local `make generate-cmd && make install`. 

I'm guessing at which of the makefile's features we actually want to do CI on; edits welcome if I've guessed incorrectly. 
